### PR TITLE
Stop TravisCI to upload deb to Bintray. because it's taken over by Je…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,18 +18,8 @@ addons:
 
 after_success:
  - ./extra/make-testcoveralls.sh
-
-before_deploy:
+ # below is the placeholder to leverage TravisCI to verify building capability is good. will be replaced by npm package build.
  - ./extra/make-deb.sh
-
-deploy: 
-  provider: bintray
-  file: .bintray.json
-  user: $BINTRAY_USER
-  key: $BINTRAY_KEY
-  on:
-    branch: master
-    node: "4"
 
 notifications:
   slack:


### PR DESCRIPTION
…nkins with better version control and tests.